### PR TITLE
Game over messages, fixed memory leak, responsiveness

### DIFF
--- a/main.c
+++ b/main.c
@@ -62,6 +62,7 @@ int main(void)
       idle();
     }
 
+    nSDL_FreeFont(font);
     SDL_Quit();
 
     return EXIT_SUCCESS;

--- a/main.c
+++ b/main.c
@@ -7,6 +7,8 @@
 #include "./logic.h"
 #include "./rendering.h"
 
+nSDL_Font *font;
+
 int main(void)
 {
     if (SDL_Init(SDL_INIT_VIDEO) != 0) {
@@ -20,6 +22,8 @@ int main(void)
         fprintf(stderr, "SDL_CreateRenderer Error: %s\n", SDL_GetError());
         return EXIT_FAILURE;
     }
+
+    font = nSDL_LoadFont(NSDL_FONT_VGA, 255, 255, 255);
 
     game_t game = {
         .board = { EMPTY, EMPTY, EMPTY,

--- a/main.c
+++ b/main.c
@@ -35,8 +35,10 @@ int main(void)
 
     while (game.state != QUIT_STATE) {
         
-      if (isKeyPressed(KEY_NSPIRE_ESC))
+      if (isKeyPressed(KEY_NSPIRE_ESC)) {
 	game.state = QUIT_STATE;
+	break;
+      }
       else if (isKeyPressed(KEY_NSPIRE_1))
 	click_on_cell(&game, 2, 0);
       else if (isKeyPressed(KEY_NSPIRE_2))
@@ -60,6 +62,7 @@ int main(void)
       render_game(screen, &game);
       SDL_Flip(screen);
       idle();
+      wait_key_pressed();
     }
 
     nSDL_FreeFont(font);

--- a/rendering.c
+++ b/rendering.c
@@ -9,6 +9,7 @@ const SDL_Color GRID_COLOR = { .r = 255, .g = 255, .b = 255, .unused = 255 };
 const SDL_Color PLAYER_X_COLOR = { .r = 255, .g = 50, .b = 50, .unused = 255};
 const SDL_Color PLAYER_O_COLOR = { .r = 50, .g = 100, .b = 255, .unused = 128};
 const SDL_Color TIE_COLOR = { .r = 100, .g = 100, .b = 100, .unused = 100 };
+extern nSDL_Font *font;
 
 void render_grid(SDL_Surface *renderer, const SDL_Color *color)
 {
@@ -112,6 +113,18 @@ void render_game_over_state(SDL_Surface *renderer,
                  game->board,
                  color,
                  color);
+
+    switch (game->player) {
+    case 1:
+      nSDL_DrawString(renderer, font, SCREEN_WIDTH / 3, SCREEN_HEIGHT / 2, "Player O won.");
+      break;
+    case 2:
+      nSDL_DrawString(renderer, font, SCREEN_WIDTH / 3, SCREEN_HEIGHT / 2, "Player X won.");
+      break;
+    default:
+      nSDL_DrawString(renderer, font, SCREEN_WIDTH / 3, SCREEN_HEIGHT / 2, "WTF!? Unknown player won.");
+      break;
+    }
 }
 
 void render_game(SDL_Surface *renderer, const game_t *game)

--- a/rendering.c
+++ b/rendering.c
@@ -8,6 +8,11 @@
 const SDL_Color GRID_COLOR = { .r = 255, .g = 255, .b = 255, .unused = 255 };
 const SDL_Color PLAYER_X_COLOR = { .r = 255, .g = 50, .b = 50, .unused = 255};
 const SDL_Color PLAYER_O_COLOR = { .r = 50, .g = 100, .b = 255, .unused = 128};
+const char *messages[] = { "WTF?! Did you hack me?",
+			   "Player X won." ,
+			   "Player O won.",
+			   "Tie :(",
+			   "Hmm...The game should not be running anymore at this point." };
 const SDL_Color TIE_COLOR = { .r = 100, .g = 100, .b = 100, .unused = 100 };
 extern nSDL_Font *font;
 
@@ -113,23 +118,8 @@ void render_game_over_state(SDL_Surface *renderer,
                  game->board,
                  color,
                  color);
-
-    char *message;
-
-    switch (game->player) {
-    case 1:
-      message = "Player O won.";
-      break;
-    case 2:
-      message = "Player X won.";
-      break;
-    default:
-      message = "WTF!? Unknown player won.";
-      break;
-    }
-
-    int width = nSDL_GetStringWidth(font, message);
-    nSDL_DrawString(renderer, font, (SCREEN_WIDTH - width) * 0.5, SCREEN_HEIGHT * 0.5, message);
+    int width = nSDL_GetStringWidth(font, messages[game->state]);
+    nSDL_DrawString(renderer, font, (SCREEN_WIDTH - width) * 0.5, SCREEN_HEIGHT * 0.5, messages[game->state]);
 }
 
 void render_game(SDL_Surface *renderer, const game_t *game)

--- a/rendering.c
+++ b/rendering.c
@@ -114,17 +114,22 @@ void render_game_over_state(SDL_Surface *renderer,
                  color,
                  color);
 
+    char *message;
+
     switch (game->player) {
     case 1:
-      nSDL_DrawString(renderer, font, SCREEN_WIDTH / 3, SCREEN_HEIGHT / 2, "Player O won.");
+      message = "Player O won.";
       break;
     case 2:
-      nSDL_DrawString(renderer, font, SCREEN_WIDTH / 3, SCREEN_HEIGHT / 2, "Player X won.");
+      message = "Player X won.";
       break;
     default:
-      nSDL_DrawString(renderer, font, SCREEN_WIDTH / 3, SCREEN_HEIGHT / 2, "WTF!? Unknown player won.");
+      message = "WTF!? Unknown player won.";
       break;
     }
+
+    int width = nSDL_GetStringWidth(font, message);
+    nSDL_DrawString(renderer, font, (SCREEN_WIDTH - width) * 0.5, SCREEN_HEIGHT * 0.5, message);
 }
 
 void render_game(SDL_Surface *renderer, const game_t *game)


### PR DESCRIPTION
* Freeing font before exit (solves issue that when you play too often, the application would crash and the os cannot do anything anymore because all the memory is marked as in use)
* Wait by blocking for key press -> improves responsiveness
* Messages in game over state